### PR TITLE
Feature/wf 90 - Permissions based on the role

### DIFF
--- a/src/components/popup-components/ManagePopup.jsx
+++ b/src/components/popup-components/ManagePopup.jsx
@@ -88,7 +88,7 @@ const ManagePopup = () => {
           </ul>
 
           {typeof current.data !== "undefined" &&
-          current.data.status === "success" ? (
+          current.data.status === "successs" ? (
             <div className="input__msg input__msg--success">
               <i class="fa fa-check"></i> Usuario actualizado correctamente
             </div>
@@ -100,6 +100,16 @@ const ManagePopup = () => {
           current.data.status === "member deleted" ? (
             <div className="input__msg input__msg--success">
               <i className="fa fa-check"></i> Usuario eliminado correctamente
+            </div>
+          ) : (
+            ""
+          )}
+
+          {typeof current.data !== "undefined" &&
+          current.data.status === "fail" ? (
+            <div className="input__msg input__msg--error">
+              <i className="fa fa-times"></i> Esta acción sobrepasa tus
+              permisos. Contáctate con tu superior.
             </div>
           ) : (
             ""

--- a/src/pages/profile-page/EmpresaProfilePage.jsx
+++ b/src/pages/profile-page/EmpresaProfilePage.jsx
@@ -70,14 +70,28 @@ const EmpresaProfilePage = (props) => {
               nunca dar tu constraseña a ningún usuario a través de WorKn, los
               administradores nunca te la solicitarán.
             </span>
-            <button className="userprofile__action" onClick={showMembersModal}>
-              <i className="fa fa-cog userprofile__icon"></i>
-              Manejar invitaciones de miembros
-            </button>
-            <button className="userprofile__action" onClick={ShowManageModal}>
-              <i className="fa fa-cog userprofile__icon"></i>
-              Manejar miembros
-            </button>
+            {typeof state.userInformation.organizationRole !== "undefined" &&
+            (state.userInformation.organizationRole === "owner" ||
+              state.userInformation.organizationRole === "supervisor") ? (
+              <div>
+                <button
+                  className="userprofile__action"
+                  onClick={showMembersModal}
+                >
+                  <i className="fa fa-cog userprofile__icon"></i>
+                  Manejar invitaciones de miembros
+                </button>
+                <button
+                  className="userprofile__action"
+                  onClick={ShowManageModal}
+                >
+                  <i className="fa fa-cog userprofile__icon"></i>
+                  Manejar miembros
+                </button>
+              </div>
+            ) : (
+              ""
+            )}
             <Link to="/manageoffers">
               <button className="userprofile__action">
                 <i className="fa fa-cog userprofile__icon"></i>

--- a/src/pages/profile-page/UserProfilePage.js
+++ b/src/pages/profile-page/UserProfilePage.js
@@ -47,8 +47,10 @@ const UserProfilePage = (props) => {
               <i className="fa fa-cog userprofile__icon"></i>
               Cambiar constraseña
             </button>
-            {typeof state.userInformation.organizationRole !== "undefined" &&
-            state.userInformation.organizationRole === "owner" ? (
+            {(typeof (state.userInformation.organizationRole !== "undefined") &&
+              state.userInformation.organizationRole === "owner") ||
+            state.userInformation.organizationRole === "member" ||
+            state.userInformation.organizationRole === "supervisor" ? (
               <Link to="/empresaprofilepage" style={{ textDecoration: "none" }}>
                 <button className="userprofile__action">
                   <i className="fa fa-cog userprofile__icon"></i>

--- a/src/utils/apiRequests.js
+++ b/src/utils/apiRequests.js
@@ -315,7 +315,7 @@ export const removeMember = async (id) => {
     );
     return response;
   } catch (e) {
-    return e.response.data;
+    return e.response;
   }
 };
 
@@ -327,7 +327,7 @@ export const updateMemberRole = async (id, role) => {
     });
     return response;
   } catch (e) {
-    return e.response.data;
+    return e.response;
   }
 };
 


### PR DESCRIPTION
**Changes**

- Implemented permission levels based on the user roles
- Owners can do every single action on organizations
- Supervisor can do every single action on organizations but only manage users that are below their role, that means that a supervisor cant delete or modify the information of  another supervisor or the owner, perhaps, **only the owner** can do this.
- Members can only manage offers.